### PR TITLE
Add GZIP support to reduce file size

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from flask import Flask, jsonify, abort, make_response, render_template, request
 from flask.json import JSONEncoder
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from flask_compress import Compress
 
 from amiibo.amiibo import (
     Hex,
@@ -69,6 +70,7 @@ class AmiiboJSONEncoder(JSONEncoder):
 
 app = Flask(__name__)
 app.json_encoder = AmiiboJSONEncoder
+Compress(app)
 
 amiibo_manager = AmiiboManager.from_json()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask_limiter
 gunicorn
 requests
 cached_property
+flask-compress


### PR DESCRIPTION
AmiiboAPI is sending pure text uncompressed. This adds GZIP support which should reduce the bandwidth used by a substantial amount and should also improve download speed.

Before:
<img width="1436" alt="screen shot 2017-08-16 at 02 26 22" src="https://user-images.githubusercontent.com/1031451/29343728-f60614f4-822a-11e7-9043-161e0e7b48cf.png">

After:
<img width="1440" alt="screen shot 2017-08-16 at 02 26 28" src="https://user-images.githubusercontent.com/1031451/29343731-f793e148-822a-11e7-949c-ab6b686e24e7.png">
