### PR TITLE
Fix for Dockerfile smell DL3006

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM busybox:1.36.0-glibc
 COPY . /amiiboapi
 RUN [ "rm", "-rf", "/amiiboapi/.git" ]
 RUN [ "rm", "-rf", "/amiiboapi/images" ]


### PR DESCRIPTION
# Infomation
Please use the following form when doing a pull request for amiibo database. Do update the `amiibo.json` and  `game_info.json` file to prevent error and make sure proper testing had been done. If unsure on `game_info.json` please use the following format attached below and just set the games as empty array, as it will be auto generated. Tick the `checklist` before submitting to ensure you have all the required information.

# Pull request form
### Checklist
 - [ ] The ids provided are not spoof.
 - [ ] The ids provided are all in lowercase.
 - [ ] The `game_info.json` had been updated with the corresponding ids.
 - [ ] Images of amiibo had been provided with the highest quality.

### Link to amiibo.life for amiibo
None

# Example for empty game_info
None

# Description
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3006](https://github.com/hadolint/hadolint/wiki/DL3006) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3006 occurs when the image tag for the base image is missing.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for the given base image. In detail, it selects the most recent image tag which corresponds to the same image digest that currently corresponds to the "latest" tag, used by default when pulling the image from DockerHub if a specific image tag is missing.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance