### PR TITLE
Less strict queries - Issue #132

### DIFF
--- a/amiibo/filterable.py
+++ b/amiibo/filterable.py
@@ -127,7 +127,7 @@ class FilterableCollection(metaclass=FilterableCollectionMeta):
     @filterable('name')
     def filter_name(self, value):
         value = value.lower()
-        return lambda x: x.name.lower() == value
+        return lambda x: value in x.name.lower()
 
     @sortable('id')
     def sort_id(self):
@@ -154,7 +154,7 @@ class AmiiboCollection(FilterableCollection):
     @filterable('game_series_id')
     def filter_game_series_id(self, value):
         return lambda x: x.game_series.id == value
-        
+
     @filterable('game_series_name')
     def filter_game_series_name(self, value):
         value = value.lower() if value else value
@@ -179,7 +179,7 @@ class AmiiboCollection(FilterableCollection):
     @filterable('character_name')
     def filter_character_name(self, value):
         value = value.lower() if value else value
-        return lambda x: x.character.name.lower() == value
+        return lambda x: value in x.character.name.lower()
 
     @filterable('variant_id')
     def filter_variant_id(self, value):

--- a/amiibo/filterable.py
+++ b/amiibo/filterable.py
@@ -158,7 +158,7 @@ class AmiiboCollection(FilterableCollection):
     @filterable('game_series_name')
     def filter_game_series_name(self, value):
         value = value.lower() if value else value
-        return lambda x: x.game_series.name.lower() == value
+        return lambda x: value in x.game_series.name.lower()
 
     @filterable('switch_titleid')
     def filter_switch_titleid(self, value):
@@ -205,7 +205,7 @@ class AmiiboCollection(FilterableCollection):
     @filterable('amiibo_series_name')
     def filter_amiibo_series_name(self, value):
         value = value.lower() if value else value
-        return lambda x: x.amiibo_series.name.lower() == value
+        return lambda x: value in x.amiibo_series.name.lower()
 
     @sortable('game_series_id')
     def sort_game_series_id(self):

--- a/database/games_info.json
+++ b/database/games_info.json
@@ -3821,18 +3821,6 @@
 					]
 				},
 				{
-					"gameName": "Super Smash Bros. Ultimate",
-					"gameID": [
-						"01006A800016E000"
-					],
-					"amiiboUsage": [
-						{
-							"Usage": "Battle and train up a computer-controlled Figure Player of the character",
-							"write": true
-						}
-					]
-				},
-				{
 					"gameName": "Yoshi's Crafted World",
 					"gameID": [
 						"01006000040C2000"
@@ -17226,7 +17214,11 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Bring Epona into the game as a rideable horse",
+							"write": false
+						},
+						{
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -17619,7 +17611,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -18012,7 +18004,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -18413,7 +18405,11 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Bring Epona into the game as a rideable horse",
+							"write": false
+						},
+						{
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -18806,7 +18802,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -19199,7 +19195,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -19592,7 +19588,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -19985,7 +19981,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -20366,7 +20362,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -20771,7 +20767,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -21164,19 +21160,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive weapons and materials, as well as a special fabric for Link’s paraglider",
-							"write": false
-						}
-					]
-				},
-				{
-					"gameName": "The Legend of Zelda: Tears of the Kingdom",
-					"gameID": [
-						"0100F2C0115B6000"
-					],
-					"amiiboUsage": [
-						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -21567,7 +21551,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -21970,7 +21954,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -22310,7 +22294,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -22662,7 +22646,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -23014,7 +22998,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -23354,7 +23338,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -23718,7 +23702,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -24031,7 +24015,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -24264,7 +24248,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -24398,7 +24382,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -24532,7 +24516,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -24666,7 +24650,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -24800,7 +24784,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -24949,7 +24933,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -25098,7 +25082,7 @@
 					],
 					"amiiboUsage": [
 						{
-							"Usage": "Receive helpful materials, weapons, or a paraglider fabric depending on the character",
+							"Usage": "Receive materials and a weapon or rare item",
 							"write": false
 						}
 					]
@@ -25606,6 +25590,18 @@
 					"amiiboUsage": [
 						{
 							"Usage": "Unlock a character-themed accessory",
+							"write": false
+						}
+					]
+				},
+				{
+					"gameName": "WarioWare Gold",
+					"gameID": [
+						"00040000001D1C00"
+					],
+					"amiiboUsage": [
+						{
+							"Usage": "Receive a sketch of the character from Wario which can be exchanged for in-game coins",
 							"write": false
 						}
 					]
@@ -49188,21 +49184,6 @@
 		},
 		"0x0286000103130502": {
 			"games3DS": [
-				{
-					"gameName": "Animal Crossing: New Leaf",
-					"gameID": [
-						"0004000000086400",
-						"0004000000086300",
-						"0004000000198F00",
-						"0004000000198E00"
-					],
-					"amiiboUsage": [
-						{
-							"Usage": "Invite the character to visit your RV campsite, give you an item, and/or move to your town",
-							"write": false
-						}
-					]
-				},
 				{
 					"gameName": "Kirby: Planet Robobot",
 					"gameID": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 limits==1.5.1
 MarkupSafe==2.1.2
-requests==2.26.0
+requests==2.31.0
 rfc3339==6.2
 six==1.16.0
 typing-extensions==3.10.0.2

--- a/routes/amiibo.py
+++ b/routes/amiibo.py
@@ -146,8 +146,5 @@ def route_api_amiibo():
                 if value in values
             ])
 
-    if not result:
-        abort(404)
-
     respond = jsonify({'amiibo': result})
     return respond


### PR DESCRIPTION
Fix for issue #132 
- Fix 404 returns when amiibo link is working, when it should be empty array since amiibo data is not found.
- Allow partial search for amiibo name and character name.