### PR TITLE
Add Switch 2 platform & Game information

### DIFF
--- a/amiibo/amiibo.py
+++ b/amiibo/amiibo.py
@@ -130,7 +130,7 @@ class UnknownMask(Hex):
 
 
 class Amiibo:
-    def __init__(self, manager, head, tail, name, release, games3DS, gamesWiiU, gamesSwitch):
+    def __init__(self, manager, head, tail, name, release, games3DS, gamesWiiU, gamesSwitch, gamesSwitch2):
         self.manager = manager
         self.head = Hex(head)
         self.tail = Hex(tail)
@@ -139,6 +139,7 @@ class Amiibo:
         self.games3DS = games3DS
         self.gamesWiiU = gamesWiiU
         self.gamesSwitch = gamesSwitch
+        self.gamesSwitch2 = gamesSwitch2
 
     @cached_property
     def id(self):

--- a/amiibo/filterable.py
+++ b/amiibo/filterable.py
@@ -164,6 +164,10 @@ class AmiiboCollection(FilterableCollection):
     def filter_switch_titleid(self, value):
         return lambda x: any(value in game.get("gameID") for game in x.gamesSwitch)
 
+    @filterable('switch2_titleid')
+    def filter_switch2_titleid(self, value):
+        return lambda x: any(value in game.get("gameID") for game in x.gamesSwitch2)
+
     @filterable('wiiu_titleid')
     def filter_wiiu_titleid(self, value):
         return lambda x: any(value in game.get("gameID") for game in x.gamesWiiU)

--- a/amiibo/manager.py
+++ b/amiibo/manager.py
@@ -45,7 +45,8 @@ class AmiiboManager:
                     },
                     'games3DS': amiibo.games3DS,
                     'gamesWiiU': amiibo.gamesWiiU,
-                    'gamesSwitch': amiibo.gamesSwitch
+                    'gamesSwitch': amiibo.gamesSwitch,
+                    'gamesSwitch2': amiibo.gamesSwitch2
                 }
                 for amiibo in self.amiibosfull
             },
@@ -83,7 +84,7 @@ class AmiiboManager:
                         jp=AmiiboManager._parse_date(amiibo['release']['jp']),
                         eu=AmiiboManager._parse_date(amiibo['release']['eu']),
                         au=AmiiboManager._parse_date(amiibo['release']['au']),
-                ), data1['amiibos'][id_]['games3DS'], data1['amiibos'][id_]['gamesWiiU'], data1['amiibos'][id_]['gamesSwitch'])
+                ), data1['amiibos'][id_]['games3DS'], data1['amiibos'][id_]['gamesWiiU'], data1['amiibos'][id_]['gamesSwitch'], data1['amiibos'][id_]['gamesSwitch2'])
                 for id_, amiibo in data['amiibos'].items()
         )
 
@@ -93,10 +94,16 @@ class AmiiboManager:
                         jp=AmiiboManager._parse_date(amiibo['release']['jp']),
                         eu=AmiiboManager._parse_date(amiibo['release']['eu']),
                         au=AmiiboManager._parse_date(amiibo['release']['au']),
-                ), data1['amiibos'][id_]['games3DS'], data1['amiibos'][id_]['gamesWiiU'], data1['amiibos'][id_]['gamesSwitch'])
+                ), data1['amiibos'][id_]['games3DS'], data1['amiibos'][id_]['gamesWiiU'], data1['amiibos'][id_]['gamesSwitch'], data1['amiibos'][id_]['gamesSwitch2'])
                 for id_, amiibo in data['amiibos'].items()
         )
         for amiibo in self.amiibosfullwithoutusage:
+            amiibo.gamesSwitch2 = copy.deepcopy(amiibo.gamesSwitch2)
+            for game in amiibo.gamesSwitch2:
+                try:
+                    del game['amiiboUsage']
+                except:
+                    pass
             amiibo.gamesSwitch = copy.deepcopy(amiibo.gamesSwitch)
             for game in amiibo.gamesSwitch:
                 try:
@@ -123,11 +130,12 @@ class AmiiboManager:
                         jp=self._parse_date(amiibo['release']['jp']),
                         eu=self._parse_date(amiibo['release']['eu']),
                         au=self._parse_date(amiibo['release']['au']),
-                ), None, None, None) # TODO: add custom Amiibo class that doesn't need the games
+                ), None, None, None, None) # TODO: add custom Amiibo class that doesn't need the games
                 for id_, amiibo in data['amiibos'].items()
         )
         for amiibo in self.amiibos:
             try:
+                del amiibo.gamesSwitch2
                 del amiibo.gamesSwitch
                 del amiibo.games3DS
                 del amiibo.gamesWiiU

--- a/checkfulldatabase.py
+++ b/checkfulldatabase.py
@@ -257,6 +257,7 @@ for key in game_info['amiibos']:
 		validateGamePlatform('games3DS', key)
 		validateGamePlatform('gamesWiiU', key)
 		validateGamePlatform('gamesSwitch', key)
+		validateGamePlatform('gamesSwitch2', key)
 	else:
 		printError(1, 'Formatting error on game info key: ' + key)
 

--- a/commons/amiibo_json_encounter.py
+++ b/commons/amiibo_json_encounter.py
@@ -30,7 +30,7 @@ class AmiiboJSONEncoder(JSONEncoder):
                 'release': obj.release
             }
             try:
-                returner.update({'games3DS': obj.games3DS, 'gamesWiiU': obj.gamesWiiU, 'gamesSwitch': obj.gamesSwitch})
+                returner.update({'games3DS': obj.games3DS, 'gamesWiiU': obj.gamesWiiU, 'gamesSwitch': obj.gamesSwitch, 'gamesSwitch2': obj.gamesSwitch2})
             except AttributeError:
                 pass
             return returner

--- a/database/games_info.json
+++ b/database/games_info.json
@@ -99800,7 +99800,19 @@
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
 				}]
-			}]
+			}],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c0000104a81d02":
 		{
@@ -99878,7 +99890,19 @@
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
 				}]
-			}]
+			}],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c1000003890002":
 		{
@@ -99895,7 +99919,19 @@
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
 				}]
-			}]
+			}],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c1000104a91d02":
 		{
@@ -99912,373 +99948,1117 @@
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
 				}]
-			}]
+			}],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c2000004aa1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c2000104ab1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c3000004ac1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c3000104ad1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c4000004ae1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c4000104af1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c5000104b01d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c6000104b11d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c7000104b21d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c8000104b31d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c9000104b41d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34ca000104b51d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34cb000104b61d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34cc000104b71d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34cd000104b81d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34ce000104b91d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34cf000104ba1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d0000104bb1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d1000104bc1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d2000104bd1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d3000104be1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d4000104bf1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d5000104c01d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d6000104e11d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x3c80000104e81d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x3c81000104f21d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d8000104e31d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d9000104e41d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34da000104e51d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34db000104e61d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34dc000104e71d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c2000104cd1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c3000104ce1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34cc000104d71d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c4000104cf1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34cd000104d81d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d0000104db1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34ce000104d91d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c7000104d21d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34cb000104d61d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d1000104dc1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c0000104cb1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34ca000104d51d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c8000104d31d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c6000104d11d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c1000104cc1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c5000104d01d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34cf000104da1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34c9000104d41d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d2000104dd1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d3000104de1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d4000104df1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d5000104e01d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d6000104eb1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x3c80000104f11d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x3c81000104f31d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d8000104ec1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34d9000104ed1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34da000104ee1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34db000104ef1d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x34dc000104f01d02":
 		{
 			"games3DS": [],
 			"gamesWiiU": [],
-			"gamesSwitch": []
+			"gamesSwitch": [],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x3500010002e10f02":
 		{
@@ -102167,7 +102947,19 @@
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
 				}]
-			}]
+            }],
+            "gamesSwitch2": [
+            {
+                "gameName": "Street Fighter 6",
+                "gameID": [
+                    "040078001CCF6000"
+                ],
+                "amiiboUsage": [
+                {
+                    "Usage": "Save and load outfit, color, and button settings / Scan another player's amiibo to friend or follow them",
+                    "write": true
+                }]
+            }]
 		},
 		"0x3dc0000004220002":
 		{

--- a/database/games_info.json
+++ b/database/games_info.json
@@ -13864,6 +13864,18 @@
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
 				}]
+			}],
+			"gamesSwitch2": [
+			{
+				"gameName": "Donkey Kong Bananza",
+				"gameID": [
+					"040074A01BF12000"
+				],
+				"amiiboUsage": [
+				{
+					"Usage": "Spawn explosive golden KONG tiles",
+					"write": false
+				}]
 			}]
 		},
 		"0x0008000002640102":
@@ -14202,6 +14214,18 @@
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
 				}]
+			}],
+			"gamesSwitch2": [
+			{
+				"gameName": "Donkey Kong Bananza",
+				"gameID": [
+					"040074A01BF12000"
+				],
+				"amiiboUsage": [
+				{
+					"Usage": "Spawn explosive golden KONG tiles",
+					"write": false
+				}]
 			}]
 		},
 		"0x000800030431ff02":
@@ -14284,6 +14308,18 @@
 				{
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
+				}]
+			}],
+			"gamesSwitch2": [
+			{
+				"gameName": "Donkey Kong Bananza",
+				"gameID": [
+					"040074A01BF12000"
+				],
+				"amiiboUsage": [
+				{
+					"Usage": "Spawn explosive golden KONG tiles",
+					"write": false
 				}]
 			}]
 		},
@@ -14598,6 +14634,22 @@
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
 				}]
+			}],
+			"gamesSwitch2": [
+			{
+				"gameName": "Donkey Kong Bananza",
+				"gameID": [
+					"040074A01BF12000"
+				],
+				"amiiboUsage": [
+				{
+					"Usage": "Unlock Pauline's Diva Dress early",
+					"write": false
+				},
+				{
+					"Usage": "Spawn explosive golden KONG tiles",
+					"write": false
+				}]
 			}]
 		},
 		"0x0008ff00023b0702":
@@ -14911,6 +14963,18 @@
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
 				}]
+			}],
+			"gamesSwitch2": [
+			{
+				"gameName": "Donkey Kong Bananza",
+				"gameID": [
+						"040074A01BF12000"
+				],
+				"amiiboUsage": [
+				{
+					"Usage": "Spawn explosive golden KONG tiles",
+					"write": false
+				}]
 			}]
 		},
 		"0x00090000000d0002":
@@ -15131,6 +15195,18 @@
 				{
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
+				}]
+			}],
+			"gamesSwitch2": [
+			{
+				"gameName": "Donkey Kong Bananza",
+				"gameID": [
+					"040074A01BF12000"
+				],
+				"amiiboUsage": [
+				{
+					"Usage": "Spawn explosive golden KONG tiles",
+					"write": false
 				}]
 			}]
 		},
@@ -15378,6 +15454,18 @@
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
 				}]
+			}],
+			"gamesSwitch2": [
+			{
+				"gameName": "Donkey Kong Bananza",
+				"gameID": [
+					"040074A01BF12000"
+				],
+				"amiiboUsage": [
+				{
+					"Usage": "Spawn explosive golden KONG tiles",
+					"write": false
+				}]
 			}]
 		},
 		"0x000900030432ff02":
@@ -15449,6 +15537,18 @@
 				{
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
+				}]
+			}],
+			"gamesSwitch2": [
+			{
+				"gameName": "Donkey Kong Bananza",
+				"gameID": [
+					"040074A01BF12000"
+				],
+				"amiiboUsage": [
+				{
+					"Usage": "Spawn explosive golden KONG tiles",
+					"write": false
 				}]
 			}]
 		},
@@ -17115,6 +17215,18 @@
 				{
 					"Usage": "Battle and train up a computer-controlled Figure Player of the character",
 					"write": true
+				}]
+			}],
+			"gamesSwitch2": [
+			{
+				"gameName": "Donkey Kong Bananza",
+				"gameID": [
+					"040074A01BF12000"
+				],
+				"amiiboUsage": [
+				{
+					"Usage": "Spawn explosive golden KONG tiles",
+					"write": false
 				}]
 			}]
 		},

--- a/routes/amiibo.py
+++ b/routes/amiibo.py
@@ -49,6 +49,9 @@ def route_api_amiibo():
         if 'switch_titleid' in args:
             filters['switch_titleid'] = args['switch_titleid']
 
+        if 'switch2_titleid' in args:
+            filters['switch2_titleid'] = args['switch2_titleid']
+
         if 'wiiu_titleid' in args:
             filters['wiiu_titleid'] = args['wiiu_titleid']
 

--- a/routes/amiibofull.py
+++ b/routes/amiibofull.py
@@ -48,6 +48,9 @@ def route_api_amiibofull():
         if 'switch_titleid' in args:
             filters['switch_titleid'] = args['switch_titleid']
 
+        if 'switch2_titleid' in args:
+            filters['switch2_titleid'] = args['switch2_titleid']
+
         if 'wiiu_titleid' in args:
             filters['wiiu_titleid'] = args['wiiu_titleid']
 
@@ -104,6 +107,7 @@ def route_api_amiibofull():
                 'gameseries_id': 'game_series_id',
                 'gameseries_name': 'game_series_name',
                 'switch_titleid' : 'gamesSwitch',
+                'switch2_titleid' : 'gamesSwitch2',
                 '3ds_titleid' : 'games3DS',
                 'wiiu_titleid' : 'gamesWiiU',
                 'character': 'character_name',

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -617,10 +617,11 @@
         {
           "gameID": [
             "01006A800016E000"
-          ], 
+          ],
           "gameName": "Super Smash Bros. Ultimate"
         }
-      ], 
+      ],
+      "gamesSwitch2": [],
       "gamesWiiU": [
         {
           "gameID": [
@@ -691,6 +692,12 @@
         <tr>
             <td>gamesSwitch</td>
             <td>List of Switch games it can be used in.</td>
+            <td>Array of gameID's and name as string</td>
+            <td>json</td>
+        </tr>
+        <tr>
+            <td>gamesSwitch2</td>
+            <td>List of Switch 2 games it can be used in.</td>
             <td>Array of gameID's and name as string</td>
             <td>json</td>
         </tr>
@@ -788,16 +795,17 @@
         {
           "amiiboUsage": [
             {
-              "Usage": "Battle and train up a computer-controlled Figure Player of the character", 
+              "Usage": "Battle and train up a computer-controlled Figure Player of the character",
               "write": true
             }
-          ], 
+          ],
           "gameID": [
             "01006A800016E000"
-          ], 
+          ],
           "gameName": "Super Smash Bros. Ultimate"
         }
-      ], 
+      ],
+      "gamesSwitch2": [],
       "gamesWiiU": [
         {
           "amiiboUsage": [
@@ -880,6 +888,12 @@
         <tr>
             <td>gamesSwitch</td>
             <td>List of Switch games it can be used in.</td>
+            <td>Array of gameID's, array of uses and name as string</td>
+            <td>json</td>
+        </tr>
+        <tr>
+            <td>gamesSwitch2</td>
+            <td>List of Switch 2 games it can be used in.</td>
             <td>Array of gameID's, array of uses and name as string</td>
             <td>json</td>
         </tr>


### PR DESCRIPTION
Since the release of the Switch 2, new Amiibo have been added that have specific usage on it that the API doesn't expose. This PR aims at fixing this.

- First it adds the support for the Switch 2 as a platform.
- Second, it add information for Donkey Kong Bananza and Street Fighter 6 to various Amiibo